### PR TITLE
fix(ci): gate Dependabot auto-merge on CI passing

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -31,8 +31,15 @@ jobs:
           echo "url=$(echo "$pr" | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
 
           # Dependabot embeds a YAML block in the commit message with update-type
-          # for each dependency. Qualify if every dep is patch or minor (none major).
+          # and package-ecosystem for each dependency. Only auto-merge Cargo updates
+          # (GitHub Actions bumps share the same format but are excluded).
+          # Qualify if every dep is patch or minor (none major).
           commit_msg=$(gh api "repos/$REPO/git/commits/$SHA" --jq '.message')
+          if ! echo "$commit_msg" | grep -q 'package-ecosystem: cargo'; then
+            echo "Not a Cargo update — skipping"
+            echo "is_eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           major=$(echo "$commit_msg" \
             | grep 'update-type:' \
             | grep 'version-update:semver-major' \

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,8 +1,9 @@
 name: Dependabot Auto-Merge
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
 permissions:
   contents: write
@@ -11,33 +12,45 @@ permissions:
 jobs:
   dependabot-auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - name: Find open PR and check update type
+        id: check
+        run: |
+          pr=$(gh api "repos/$REPO/pulls" \
+            --jq "[.[] | select(.head.sha == \"$SHA\" and .state == \"open\")] | first")
+          number=$(echo "$pr" | jq -r '.number // empty')
+          if [[ -z "$number" ]]; then
+            echo "No open PR found for SHA $SHA — skipping"
+            exit 0
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "$pr" | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
 
-      - name: Get Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Auto-approve patch and minor updates for Cargo
-        if: |
-          steps.metadata.outputs.package-ecosystem == 'cargo' &&
-          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-           steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        run: gh pr review --approve "$PR_URL"
+          # Dependabot embeds a YAML block in the commit message with update-type
+          # for each dependency. Qualify if every dep is patch or minor (none major).
+          commit_msg=$(gh api "repos/$REPO/git/commits/$SHA" --jq '.message')
+          major=$(echo "$commit_msg" \
+            | grep 'update-type:' \
+            | grep 'version-update:semver-major' \
+            || true)
+          has_types=$(echo "$commit_msg" | grep -c 'update-type:' || true)
+          if [[ -z "$major" && "$has_types" -gt 0 ]]; then
+            echo "is_eligible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_eligible=false" >> "$GITHUB_OUTPUT"
+          fi
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge for patch and minor Cargo updates
-        if: |
-          steps.metadata.outputs.package-ecosystem == 'cargo' &&
-          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-           steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        run: gh pr merge --auto --squash "$PR_URL"
+      - name: Merge patch and minor updates
+        if: steps.check.outputs.number != '' && steps.check.outputs.is_eligible == 'true'
+        run: gh pr merge --squash "$PR_URL"
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_URL: ${{ steps.check.outputs.url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The previous workflow fired on `pull_request` events and called `gh pr merge --auto --squash`. Because this repository has no branch-protection rules requiring status checks, `--auto` resolves immediately — CI never had a chance to run. A failing Dependabot PR could be merged before tests reported back.

## Fix

Switch the trigger to `workflow_run` on the `CI` workflow. The job only runs when:

- the CI workflow **completed successfully** (`conclusion == 'success'`),
- it was triggered by a **pull_request** event, and
- the actor is **`dependabot[bot]`**.

This means CI must pass before the merge job even starts.

## Eligibility logic

The old workflow used `dependabot/fetch-metadata` to read the `update-type` output. That action is not available in `workflow_run` context (it needs the PR's branch checked out and Dependabot-signed metadata).

Instead, the new workflow inspects the **commit message** directly. Dependabot embeds a YAML block containing one `update-type:` line per dependency. A PR qualifies for auto-merge if:

- at least one `update-type:` line is present (guards against malformed messages), and
- **none** of the lines contain `version-update:semver-major`.

This preserves the original scope: **patch and minor** bumps are merged; major bumps require a human review.

## Checklist

- [x] `workflow_run` trigger replaces `pull_request`
- [x] Job guards on `conclusion == 'success'`
- [x] Patch **and** minor updates remain in scope (no regression from previous behaviour)
- [x] Major updates are blocked
- [x] No external actions required (no `dependabot/fetch-metadata`, no checkout)
